### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://afshinalizadehcs.visualstudio.com/0f85d5f7-be44-4eb1-bb1e-87fa42dd7ac6/f41841b4-da24-4fa5-a319-69b18eccf88e/_apis/work/boardbadge/8f92d4c6-43d4-4003-a432-b6bdc7f8c2d2)](https://afshinalizadehcs.visualstudio.com/0f85d5f7-be44-4eb1-bb1e-87fa42dd7ac6/_boards/board/t/f41841b4-da24-4fa5-a319-69b18eccf88e/Microsoft.RequirementCategory)
 # TestAzureIntegration
 Test Task Integration
 Test ab# is worked


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#7](https://afshinalizadehcs.visualstudio.com/0f85d5f7-be44-4eb1-bb1e-87fa42dd7ac6/_workitems/edit/7). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.